### PR TITLE
Make light mode the default regardless of device preference

### DIFF
--- a/src/scripts/color-mode.js
+++ b/src/scripts/color-mode.js
@@ -2,11 +2,12 @@ var colorMode = window.localStorage.getItem("color-mode");
 var colorModeButton = document.getElementById("color-mode-button"); 
 
 if(colorMode === null) {
-	if(window.matchMedia("(prefers-color-scheme: light)").matches) {
-		colorMode = "light";
-	} else {
-		colorMode = "dark";
-	}
+  colorMode = "light";
+	// if(window.matchMedia("(prefers-color-scheme: light)").matches) {
+	// 	colorMode = "light";
+	// } else {
+	// 	colorMode = "dark";
+	// }
 }
 update();
 


### PR DESCRIPTION
Literally just commented out the code that tries to figure out the device preference and instead just had it set the page to light if there was no previous setting.